### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/10_Tree_Simple_test.t
+++ b/t/10_Tree_Simple_test.t
@@ -9,7 +9,7 @@ BEGIN
 
 
 
-eval_lives_ok 'use Tree::Simple', 'Can use Tree::Simple';
+eval-lives-ok 'use Tree::Simple', 'Can use Tree::Simple';
 
 use Tree::Simple;
 
@@ -286,26 +286,26 @@ is($tree, $sub_tree_3.getParent(), '... make sure our sub_tree_3 parent is tree'
 # check that our arrays are equal
 my $children = $tree.getAllChildren();
 
-is_deeply($children, [ $sub_tree, $sub_tree_2, $sub_tree_3, $sub_tree_4]);
+is-deeply($children, [ $sub_tree, $sub_tree_2, $sub_tree_3, $sub_tree_4]);
 
 # get it in array context and
 # check that our arrays are equal
 my @children = $tree.getAllChildren();
-is_deeply(@children, [ $sub_tree, $sub_tree_2, $sub_tree_3, $sub_tree_4 ]);
+is-deeply(@children, [ $sub_tree, $sub_tree_2, $sub_tree_3, $sub_tree_4 ]);
 
 # check that the values from both
 # contexts are equal to one another
-is_deeply($children, @children);
+is-deeply($children, @children);
 
 # now check that the siblings of all the 
 # sub_trees are the same as the children
 for @children ->  $_sub_tree {
 	# test siblings in scalar context
 	my $siblings = $sub_tree.getAllSiblings();
-	is_deeply($children, $siblings);
+	is-deeply($children, $siblings);
 	# and now in array context
 	my @siblings = $sub_tree.getAllSiblings();
-	is_deeply($children, @siblings);
+	is-deeply($children, @siblings);
 }
 
 ## ----------------------------------------------------------------------------
@@ -345,7 +345,7 @@ is($sub_tree.getChildCount(), 3, '... we should have 3 children now');
 
 # now check that sub_tree's children 
 # are the same as our list
-is_deeply([ $sub_tree.getAllChildren() ], @sub_children);
+is-deeply([ $sub_tree.getAllChildren() ], @sub_children);
 
 # now go through the children again
 # and test them
@@ -366,7 +366,7 @@ for @sub_children -> $sub_child {
 	
  	# now check that its siblings are the same 
  	# as the children of its parent			
- 	is_deeply([ $sub_tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
+ 	is-deeply([ $sub_tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
 }
 
 ## ----------------------------------------------------------------------------
@@ -403,7 +403,7 @@ is($sub_tree.getChildCount(), 6, '... we should have 6 children now');
 
 # now check that sub_tree's children 
 # are the same as our list
-is_deeply([ $sub_tree.getAllChildren() ], [ @sub_children[0], @more_sub_children, @sub_children[1 .. @sub_children.end()] ]);
+is-deeply([ $sub_tree.getAllChildren() ], [ @sub_children[0], @more_sub_children, @sub_children[1 .. @sub_children.end()] ]);
 
 # now go through the children again
 # and test them
@@ -424,7 +424,7 @@ for @more_sub_children -> $sub_child {
 	
  	# now check that its siblings are the same 
  	# as the children of its parent
- 	is_deeply([ $sub_tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
+ 	is-deeply([ $sub_tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
 }
 
 ## ----------------------------------------------------------------------------
@@ -482,7 +482,7 @@ for @more_children -> $sub_child {
 	
  	# now check that its siblings are the same 
  	# as the children of its parent			
- 	is_deeply([ $tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
+ 	is-deeply([ $tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
 }
 
 ## ----------------------------------------------------------------------------
@@ -533,7 +533,7 @@ is($new_sibling.getDepth(), 0, '... depth should be 0');
 	
 # now check that its siblings are the same 
 # as the children of its parent			
-is_deeply([ $tree.getAllChildren() ], [ $new_sibling.getAllSiblings() ]);
+is-deeply([ $tree.getAllChildren() ], [ $new_sibling.getAllSiblings() ]);
 
 ## ----------------------------------------------------------------------------
 ## test inserting Siblings
@@ -593,7 +593,7 @@ for @even_more_children ->  $sub_child {
 	
  	# now check that its siblings are the same 
  	# as the children of its parent			
- 	is_deeply([ $tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
+ 	is-deeply([ $tree.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
 }
 
 ## ----------------------------------------------------------------------------
@@ -652,7 +652,7 @@ for $self_ref_tree_test.getAllChildren() -> $sub_child {
 	
  	# now check that its siblings are the same 
  	# as the children of its parent			
- 	is_deeply([ $self_ref_tree_test.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
+ 	is-deeply([ $self_ref_tree_test.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
 }
 
 ## ----------------------------------------------------------------------------	
@@ -700,7 +700,7 @@ is($sub_child.getDepth(), 2, '... depth should be 0');
 
 # now check that its siblings are the same 
 # as the children of its parent		
-is_deeply([ $self_ref_tree_test_2.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
+is-deeply([ $self_ref_tree_test_2.getAllChildren() ], [ $sub_child.getAllSiblings() ]);
 
 ## ----------------------------------------------------------------------------
 ## test removeChildAt
@@ -905,7 +905,7 @@ $tree.traverse(sub ($_tree) {
  	});
 
 # and compare the two
-is_deeply(@_all_node_values, @all_node_values, '... our nodes match our control nodes');
+is-deeply(@_all_node_values, @all_node_values, '... our nodes match our control nodes');
 
 # test traverse with both pre- and post- methods
 # make a control set of 
@@ -965,7 +965,7 @@ $tree.traverse(sub ($_tree) {
 );
 
 # and compare the two
-is_deeply(@_all_node_values_post_traverse, @all_node_values_post_traverse,
+is-deeply(@_all_node_values_post_traverse, @all_node_values_post_traverse,
    '... our nodes match our control nodes for post traverse method');
 
 
@@ -1000,9 +1000,9 @@ $tree_clone.traverse(sub ($_tree){
 	});
 
 # make sure that our cloned values equal to our control
-is_deeply(@_all_node_values, @all_cloned_node_values);
+is-deeply(@_all_node_values, @all_cloned_node_values);
 # and make sure they also match the original tree
-is_deeply(@all_node_values, @all_cloned_node_values);
+is-deeply(@all_node_values, @all_cloned_node_values);
 
 # now change all the node values
 $tree_clone.traverse(sub ($_tree){
@@ -1021,7 +1021,7 @@ $tree_clone.traverse(sub ($_tree) {
 my @_all_node_values_changed = map { ". $_" }, @_all_node_values;	
 
 # now both our changed values should be correct
-is_deeply(@_all_node_values_changed, @all_cloned_node_values_changed);
+is-deeply(@_all_node_values_changed, @all_cloned_node_values_changed);
 
 my @all_node_values_check;
 # now traverse the original tree again and make sure
@@ -1032,7 +1032,7 @@ $tree.traverse(sub ($_tree){
 
 # this can be accomplished by checking them 
 # against our control again
-is_deeply(@_all_node_values, @all_node_values_check);	
+is-deeply(@_all_node_values, @all_node_values_check);	
 	
 ## ----------------------------------------------------------------------------
 ## end test for Tree::Simple

--- a/t/11_Tree_Simple_fixDepth_test.t
+++ b/t/11_Tree_Simple_fixDepth_test.t
@@ -51,7 +51,7 @@ for $tree.getAllChildren() -> $sub_tree {
  	is($sub_tree.getDepth(), 0, '... our depth should be 0');
  	# and their siblings should match 
  	# the children of their parent
- 	is_deeply(
+ 	is-deeply(
          [ $tree.getAllChildren() ], 
          [ $sub_tree.getAllSiblings() ], 
          '... our siblings are the same');
@@ -95,7 +95,7 @@ for $parent_tree.getAllChildren() -> $sub_tree {
  	is($sub_tree.getDepth(), 0, '... our depth should be 0');
  	# and that all their siblinds match
  	# the children of their parent
- 	is_deeply(
+ 	is-deeply(
          [ $parent_tree.getAllChildren() ], 
          [ $sub_tree.getAllSiblings() ],
          '... the siblings are the same as the children');

--- a/t/12_Tree_Simple_exceptions_test.t
+++ b/t/12_Tree_Simple_exceptions_test.t
@@ -25,15 +25,15 @@ my $TEST_SUB_TREE = Tree::Simple.new("test");
 
 # not giving a proper argument for parent
 
-dies_ok( { Tree::Simple.new("test", 0) });
+dies-ok( { Tree::Simple.new("test", 0) });
 
 # not giving a proper argument for parent
-dies_ok ( {
+dies-ok ( {
 	Tree::Simple.new("test", []);
 } );
 
 # not giving a proper argument for parent
-dies_ok( {
+dies-ok( {
  	Tree::Simple.new("test", $BAD_OBJECT);
 } ) ; # qr/^Insufficient Arguments \:/, '... this should die';
 
@@ -46,7 +46,7 @@ my $tree = Tree::Simple.new($Tree::Simple::ROOT);
 # -----------------------------------------------
 
 # not giving an argument for setNodeValue
-dies_ok( {
+dies-ok( {
 	$tree.setNodeValue();
 } ) ; # qr/^Insufficient Arguments \: must supply a value for node/, '... this should die';
 
@@ -55,23 +55,23 @@ dies_ok( {
 # -----------------------------------------------
 
 # not giving an argument for addChild
-dies_ok( {
+dies-ok( {
  	$tree.addChild();
 } ) ; # qr/^Insufficient Arguments : no tree\(s\) to insert/, '... this should die';
 
 # # giving an bad argument for addChild
-dies_ok( {
+dies-ok( {
  	$tree.addChild("fail");
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # # giving an bad argument for addChild
-dies_ok( {
+dies-ok( {
  	$tree.addChild([]);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 
 # # giving an bad object argument for addChild
-dies_ok( {
+dies-ok( {
  	$tree.addChild($BAD_OBJECT);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
@@ -81,38 +81,38 @@ dies_ok( {
 
 #todo this will pass not because it validates the arguments but because their is no alias yet for InsertChild
 # giving no index argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild();
 } ) ; # qr/^Insufficient Arguments \: Cannot insert child without index/, '... this should die';
 
 # giving an out of bounds index argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild(5);
 } ) ; # qr/^Index Out of Bounds \: got \(5\) expected no more than \(0\)/, '... this should die';
 
 # giving an good index argument but no tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild(0);
 } ) ; # qr/^Insufficient Arguments \: no tree\(s\) to insert/, '... this should die';
 
 # giving an good index argument but an undefined tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild(0, Mu);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # giving an good index argument but a non-object tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild(0, "Fail");
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # # giving an good index argument but a non-object-ref tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild(0, []);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 
 # # giving an good index argument but a bad object tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChild(0, $BAD_OBJECT);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
@@ -122,38 +122,38 @@ dies_ok( {
 # -----------------------------------------------
 
 # giving no index argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt();
 } ) ; # qr/^Insufficient Arguments \: Cannot insert child without index/, '... this should die';
 
 # giving an out of bounds index argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt(5);
 } ) ; # qr/^Index Out of Bounds \: got \(5\) expected no more than \(0\)/, '... this should die';
 
 # giving an good index argument but no tree argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt(0);
 } ) ; # qr/^Insufficient Arguments \: no tree\(s\) to insert/, '... this should die';
 
 # giving an good index argument but an undefined tree argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt(0, Mu);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # giving an good index argument but a non-object tree argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt(0, "Fail");
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # # giving an good index argument but a non-object-ref tree argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt(0, []);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 
 # # giving an good index argument but a bad object tree argument for insertChildAt
-dies_ok( {
+dies-ok( {
  	$tree.insertChildAt(0, $BAD_OBJECT);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
@@ -170,38 +170,38 @@ dies_ok( {
 #todo this will pass not because it validates the arguments but because their is no alias yet for insertChildren
 
 # giving no index argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren();
 } ) ; # qr/^Insufficient Arguments \: Cannot insert child without index/, '... this should die';
 
 # giving an out of bounds index argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren(5);
 } ) ; # qr/^Index Out of Bounds \: got \(5\) expected no more than \(0\)/, '... this should die';
 
 # giving an good index argument but no tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren(0);
 } ) ; # qr/^Insufficient Arguments \: no tree\(s\) to insert/, '... this should die';
 
 # giving an good index argument but a Mu tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren(0, Mu);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # giving an good index argument but a non-object tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren(0, "Fail");
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 # giving an good index argument but a non-object-ref tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren(0, []);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
 
 # giving an good index argument but a bad object tree argument for insertChild
-dies_ok( {
+dies-ok( {
  	$tree.insertChildren(0, $BAD_OBJECT);
 } ) ; # qr/^Insufficient Arguments \: Child must be a Tree\:\:Simple object/, '... this should die';
 
@@ -211,12 +211,12 @@ dies_ok( {
 # -----------------------------------------------
 
 # giving no index argument for removeChildAt
-dies_ok( {
+dies-ok( {
  	$tree.removeChildAt();
 } ) ; # qr/^Insufficient Arguments \: Cannot remove child without index/, '... this should die';
 
 # attempt to remove a child when there are none
-dies_ok( {
+dies-ok( {
  	$tree.removeChildAt(5);
 } ) ; # qr/^Illegal Operation \: There are no children to remove/, '... this should die';
 
@@ -224,7 +224,7 @@ dies_ok( {
 $tree.addChild($TEST_SUB_TREE);
 
 # giving no index argument for removeChildAt
-dies_ok( {
+dies-ok( {
  	$tree.removeChildAt(5);
 } ) ; # qr/^Index Out of Bounds \: got \(5\) expected no more than \(1\)/, '... this should die';
 
@@ -235,22 +235,22 @@ is($tree.removeChildAt(0), $TEST_SUB_TREE, '... these should be the same');
 # -----------------------------------------------
 
 # giving no index argument for removeChild
-dies_ok( {
+dies-ok( {
  	$tree.removeChild();
 } ) ; # qr/^Insufficient Arguments \: /, '... this should die';
 
 # giving bad ref argument
-dies_ok( {
+dies-ok( {
  	$tree.removeChild([]);
 } ) ; # qr/^Insufficient Arguments \: /, '... this should die';
 
 # giving bad object argument
-dies_ok( {
+dies-ok( {
  	$tree.removeChild($BAD_OBJECT);
 } ) ; # qr/^Insufficient Arguments \: /, '... this should die';
 
 # giving bad object argument
-dies_ok( {
+dies-ok( {
  	$tree.removeChild($TEST_SUB_TREE);
 } ) ; # qr/^Child Not Found \: /, '... this should die';
 
@@ -259,22 +259,22 @@ dies_ok( {
 # -----------------------------------------------
 
 # attempting to add sibling to root trees
-dies_ok( {
+dies-ok( {
  	$tree.addSibling($TEST_SUB_TREE);
 } ) ; # qr/^Insufficient Arguments \: cannot add a sibling to a ROOT tree/, '... this should die';
 
 # attempting to add siblings to root trees
-dies_ok( {
+dies-ok( {
  	$tree.addSiblings($TEST_SUB_TREE);
 } ) ; # qr/^Insufficient Arguments \: cannot add siblings to a ROOT tree/, '... this should die';
 
 # attempting to insert sibling to root trees
-dies_ok( {
+dies-ok( {
  	$tree.insertSibling(0, $TEST_SUB_TREE);
 } ) ; # qr/^Insufficient Arguments \: cannot insert sibling\(s\) to a ROOT tree/, '... this should die';
 
 # attempting to insert sibling to root trees
-dies_ok( {
+dies-ok( {
  	$tree.insertSiblings(0, $TEST_SUB_TREE);
 } ) ; # qr/^Insufficient Arguments \: cannot insert sibling\(s\) to a ROOT tree/, '... this should die';
 
@@ -283,7 +283,7 @@ dies_ok( {
 # -----------------------------------------------
 
 # # not giving an index to the getChild method
-dies_ok( {
+dies-ok( {
  	$tree.getChild();
 } ) ; # qr/^Insufficient Arguments \: Cannot get child without index/, '... this should die';
 
@@ -292,12 +292,12 @@ dies_ok( {
 # -----------------------------------------------
 
 # trying to get siblings of a root tree
-dies_ok( {
+dies-ok( {
  	$tree.getSibling();
 } ) ; # qr/^Insufficient Arguments \: cannot get siblings from a ROOT tree/, '... this should die';
 
 # trying to get siblings of a root tree
-dies_ok( {
+dies-ok( {
  	$tree.getAllSiblings();
 } ) ; # qr/^Insufficient Arguments \: cannot get siblings from a ROOT tree/, '... this should die';
 
@@ -306,27 +306,27 @@ dies_ok( {
 # -----------------------------------------------
 
 # passing no args to traverse
-dies_ok( {
+dies-ok( {
  	$tree.traverse();
 } ) ; # qr/^Insufficient Arguments \: Cannot traverse without traversal function/, '... this should die';
 
 # passing non-ref arg to traverse
-dies_ok( {
+dies-ok( {
  	$tree.traverse("Fail");
 } ) ; # qr/^Incorrect Object Type \: traversal function is not a function/, '... this should die';
 
 # passing non-code-ref arg to traverse
-dies_ok( {
+dies-ok( {
  	$tree.traverse($BAD_OBJECT);
 } ) ; # qr/^Incorrect Object Type \: traversal function is not a function/, '... this should die';
 
 # passing second non-ref arg to traverse
-dies_ok( {
+dies-ok( {
  	$tree.traverse(sub {}, "Fail");
 } ) ; # qr/^Incorrect Object Type \: post traversal function is not a function/, '... this should die';
 
 # passing second non-code-ref arg to traverse
-dies_ok( {
+dies-ok( {
  	$tree.traverse(sub {}, $BAD_OBJECT);
 } ) ; # qr/^Incorrect Object Type \: post traversal function is not a function/, '... this should die';
 
@@ -337,22 +337,22 @@ dies_ok( {
 
 #todo have not implemented vistor class or methods
 # passing no args to accept
-#dies_ok( {
+#dies-ok( {
 # 	$tree.accept();
 #} ) ; # qr/^Insufficient Arguments \: You must supply a valid Visitor object/, '... this should die';
 
 # # passing non-ref arg to accept
-#dies_ok( {
+#dies-ok( {
 # 	$tree.accept("Fail");
 #} ) ; # qr/^Insufficient Arguments \: You must supply a valid Visitor object/, '... this should die';
 
 # # passing non-object-ref arg to accept
-#dies_ok( {
+#dies-ok( {
 # 	$tree.accept([]);
 #} ) ; # qr/^Insufficient Arguments \: You must supply a valid Visitor object/, '... this should die';
 
 # # passing non-Tree::Simple::Visitor arg to accept
-#dies_ok( {
+#dies-ok( {
 # 	$tree.accept($BAD_OBJECT);
 #} ) ; # qr/^Insufficient Arguments \: You must supply a valid Visitor object/, '... this should die';
 
@@ -371,23 +371,23 @@ dies_ok( {
 # # -----------------------------------------------
 #todo may remove setParent completely
 # # if no parent is given
-#dies_ok( {
+#dies-ok( {
 # 	$tree.setParent();
 #} ) ; # qr/^Insufficient Arguments/, '... this should croak';
 
 # # if the parent that is given is not an object
-#dies_ok( {
+#dies-ok( {
 # 	$tree.setParent("Test");
 #} ) ; # qr/^Insufficient Arguments/, '... this should croak';
 
 # # if the parent that is given is a ref but not an object
-#dies_ok( {
+#dies-ok( {
 # 	$tree.setParent([]);
 #} ) ; # qr/^Insufficient Arguments/, '... this should croak';
 
 # # and if the parent that is given is an object but
 # # is not a Tree::Simple object
-#dies_ok( {
+#dies-ok( {
 # 	$tree.setParent($BAD_OBJECT);
 #} ) ; # qr/^Insufficient Arguments/, '... this should croak';
 
@@ -395,7 +395,7 @@ dies_ok( {
 # exceptions for setUID
 # -----------------------------------------------
 
-dies_ok( {
+dies-ok( {
  	$tree.setUID();
 } ) ; # qr/^Insufficient Arguments/, '... this should croak';
 

--- a/t/13_Tree_Simple_clone_test.t
+++ b/t/13_Tree_Simple_clone_test.t
@@ -72,7 +72,7 @@ is($tree.getChild(2).getNodeValue().WHAT, Array, '... these should be array refs
 isnt($clone.getChild(2).getNodeValue().WHERE, $tree.getChild(2).getNodeValue().WHERE, 
  	'... these should be different array refs');	
 # with the same value	
-is_deeply(
+is-deeply(
     $clone.getChild(2).getNodeValue(), 
     $tree.getChild(2).getNodeValue(), 
 	'... these should have the same contents');
@@ -84,7 +84,7 @@ is($tree.getChild(3).getNodeValue().WHAT, Hash, '... these should be hash refs')
 isnt($clone.getChild(3).getNodeValue().WHERE, $tree.getChild(3).getNodeValue().WHERE, 
  	'... these should be different hash refs');	
 # with the same value	
-is_deeply(
+is-deeply(
      $clone.getChild(3).getNodeValue(), 
      $tree.getChild(3).getNodeValue(), 
 	'... these should have the same contents');	
@@ -139,7 +139,7 @@ my $shallow_clone = $tree.cloneShallow();
 
 isnt($shallow_clone.WHICH, $tree.WHICH, '... these should be refs');
 
-is_deeply(
+is-deeply(
  		 $shallow_clone.getAllChildren() ,
  		 $tree.getAllChildren() ,
 		'... the children are the same');

--- a/t/14_Tree_Simple_leak_test.t
+++ b/t/14_Tree_Simple_leak_test.t
@@ -9,7 +9,7 @@ BEGIN
 
 
 
-eval_lives_ok 'use Tree::Simple', 'Can use Tree::Simple';
+eval-lives-ok 'use Tree::Simple', 'Can use Tree::Simple';
 
 use Tree::Simple;
 #since do not have Test::Memory::Cycle module, so just testing the destroy function

--- a/t/14a_Tree_Simple_weak_refs_test.t
+++ b/t/14a_Tree_Simple_weak_refs_test.t
@@ -9,7 +9,7 @@ BEGIN
 
 
 
-eval_lives_ok 'use Tree::Simple', 'Can use Tree::Simple';
+eval-lives-ok 'use Tree::Simple', 'Can use Tree::Simple';
 
 use Tree::Simple;
 #todo not sure if we want/need weak reference just yet. Hence will leave it for now

--- a/t/16_Tree_Simple_width_test.t
+++ b/t/16_Tree_Simple_width_test.t
@@ -12,11 +12,11 @@ use Tree::Simple;
 { # test height (with pictures)
     
     my $tree = Tree::Simple.new();
-    isa_ok($tree, Tree::Simple);
+    isa-ok($tree, Tree::Simple);
 
     
     my $D = Tree::Simple.new('D');
-    isa_ok($D, Tree::Simple);    
+    isa-ok($D, Tree::Simple);    
 
     
     $tree.addChild($D);
@@ -27,7 +27,7 @@ use Tree::Simple;
     is($D.getWidth(), 1, '... D has a width of 1');
     
     my $E = Tree::Simple.new('E');
-    isa_ok($E, Tree::Simple);
+    isa-ok($E, Tree::Simple);
     
     $D.addChild($E);
     
@@ -40,7 +40,7 @@ use Tree::Simple;
     is($E.getWidth(), 1, '... E has a width of 1');
     
     my $F = Tree::Simple.new('F');
-    isa_ok($F, Tree::Simple);
+    isa-ok($F, Tree::Simple);
     
     $E.addChild($F);
     
@@ -56,7 +56,7 @@ use Tree::Simple;
     is($F.getWidth(), 1, '... F has a width of 1');
     
     my $C = Tree::Simple.new('C');
-    isa_ok($C, Tree::Simple);
+    isa-ok($C, Tree::Simple);
     
     $D.addChild($C);
     
@@ -73,7 +73,7 @@ use Tree::Simple;
     is($C.getWidth(), 1, '... C has a width of 1');
     
     my $B = Tree::Simple.new('B');
-    isa_ok($B, Tree::Simple);
+    isa-ok($B, Tree::Simple);
     
     $D.addChild($B);
     
@@ -93,7 +93,7 @@ use Tree::Simple;
         
     
     my $A = Tree::Simple.new('A');
-    isa_ok($A, Tree::Simple);
+    isa-ok($A, Tree::Simple);
     
     $E.addChild($A);
     
@@ -112,7 +112,7 @@ use Tree::Simple;
     is($A.getWidth(), 1, '... A has a width of 1');
     
     my $G = Tree::Simple.new('G');
-    isa_ok($G, Tree::Simple);
+    isa-ok($G, Tree::Simple);
     #TODO need to make alias for 'insertChild' that direct to insertChildAt 
     $E.insertChildAt(1, $G);
     
@@ -132,7 +132,7 @@ use Tree::Simple;
     is($A.getWidth(), 1, '... A has a width of 1');
     
     my $H = Tree::Simple.new('H');
-    isa_ok($H, Tree::Simple);
+    isa-ok($H, Tree::Simple);
     
     $G.addChild($H);
     
@@ -155,7 +155,7 @@ use Tree::Simple;
     is($A.getWidth(), 1, '... A has a width of 1');
     
     my $I = Tree::Simple.new('I');
-    isa_ok($I, Tree::Simple);
+    isa-ok($I, Tree::Simple);
     
     $G.addChild($I);
     

--- a/t/20_Tree_Simple_Visitor_test.t
+++ b/t/20_Tree_Simple_Visitor_test.t
@@ -34,7 +34,7 @@ $tree.accept($visitor);
 
 ok $visitor.can('getResults'),"Can do getResults";
 
-is_deeply([ $visitor.getResults() ], [ <1 1.1 1.2 1.2.1 1.3 2 3>],
+is-deeply([ $visitor.getResults() ], [ <1 1.1 1.2 1.2.1 1.3 2 3>],
          '... got what we expected');
 
 ok($visitor.can('setNodeFilter'));
@@ -48,15 +48,15 @@ is($visitor.getNodeFilter(), "$node_filter", '... got back what we put in');
 # visit the tree again to get new results now
 $tree.accept($visitor);
 
-is_deeply($visitor.getResults(),[ <_1 _1.1 _1.2 _1.2.1 _1.3 _2 _3>],
+is-deeply($visitor.getResults(),[ <_1 _1.1 _1.2 _1.2.1 _1.3 _2 _3>],
          '... got what we expected');
         
 # test some exceptions
-dies_ok ({
+dies-ok ({
      $visitor.setNodeFilter();        
 });
 
-dies_ok ({
+dies-ok ({
      $visitor.setNodeFilter([]);        
 });
 
@@ -87,23 +87,23 @@ ok($visitor3 ~~ Tree::Simple::Visitor);
 # -----------------------------------------------
 
 # we pass a bad depth (string)
-dies_ok ({
+dies-ok ({
     my $test = Tree::Simple::Visitor.new($SIMPLE_SUB, "Fail")
 });
    
 # we pass a bad depth (numeric)
-dies_ok ({
+dies-ok ({
 my $test = Tree::Simple::Visitor.new($SIMPLE_SUB, 100);
 });
 
 # we pass a non-ref func argument
-dies_ok ({
+dies-ok ({
  	my $test = Tree::Simple::Visitor.new("Fail");
 });
 
 
 # # we pass a non-code-ref func arguement   
-dies_ok ({
+dies-ok ({
  	my $test = Tree::Simple::Visitor.new([]);
 });
 
@@ -117,21 +117,21 @@ dies_ok ({
 ok($visitor1.can('visit'));
 
 # test no arg
-dies_ok ( {
+dies-ok ( {
  	$visitor1.visit();
 });
 
 #    '... we are expecting this error'; 
    
 # test non-ref arg
-dies_ok ( {
+dies-ok ( {
  	$visitor1.visit("Fail");
 });
 
 #    '... we are expecting this error'; 	 
    
 # test non-object ref arg
-dies_ok ( {
+dies-ok ( {
  	$visitor1.visit([]);
  });
 
@@ -140,7 +140,7 @@ class BAD {};
 my $BAD_OBJECT = BAD.new();   
    
 # test non-Tree::Simple object arg
-dies_ok ( {
+dies-ok ( {
  	$visitor1.visit($BAD_OBJECT);
 });
 
@@ -166,17 +166,17 @@ ok($tree1 ~~ Tree::Simple);
 is($tree1.getChildCount(), 3, '... there are 3 children here');
 
 #and pass the visitor1 to accept
-lives_ok( {
+lives-ok( {
  	$tree1.accept($visitor1);
 }, '.. this passes fine');
 
 # and pass the visitor2 to accept
-lives_ok( {
+lives-ok( {
  	$tree1.accept($visitor2);
 }, '.. this passes fine');
 
 # and pass the visitor3 to accept
-lives_ok( {
+lives-ok( {
 	$tree1.accept($visitor3);
 }, '.. this passes fine');
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -8,7 +8,7 @@ BEGIN
 }
 
 
-skip_rest('Do not have Test::Pod module');
+skip-rest('Do not have Test::Pod module');
 # eval "use Test::Pod 1.14";
 # plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
 

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -8,7 +8,7 @@ BEGIN
 }
 
 
-skip_rest('Do not have Test::Pod::Coverage module');
+skip-rest('Do not have Test::Pod::Coverage module');
 
 
 #todo do not have this testing module to check for documentation coverage


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.