### PR TITLE
Fix failures due to @*INC no longer being in Perl 6

### DIFF
--- a/t/10_Tree_Simple_test.t
+++ b/t/10_Tree_Simple_test.t
@@ -1,12 +1,7 @@
 use v6;
 use Test;
 plan 275;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
-
+use lib <lib blib>;
 
 
 eval_lives_ok 'use Tree::Simple', 'Can use Tree::Simple';

--- a/t/11_Tree_Simple_fixDepth_test.t
+++ b/t/11_Tree_Simple_fixDepth_test.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 46;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 
 ## ----------------------------------------------------------------------------

--- a/t/12_Tree_Simple_exceptions_test.t
+++ b/t/12_Tree_Simple_exceptions_test.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 50;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 use Tree::Simple;
 

--- a/t/13_Tree_Simple_clone_test.t
+++ b/t/13_Tree_Simple_clone_test.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 48;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 use Tree::Simple;
 

--- a/t/14_Tree_Simple_leak_test.t
+++ b/t/14_Tree_Simple_leak_test.t
@@ -1,12 +1,7 @@
 use v6;
 use Test;
 plan 34;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
-
+use lib <lib blib>;
 
 
 eval_lives_ok 'use Tree::Simple', 'Can use Tree::Simple';

--- a/t/14a_Tree_Simple_weak_refs_test.t
+++ b/t/14a_Tree_Simple_weak_refs_test.t
@@ -1,12 +1,7 @@
 use v6;
 use Test;
 plan 1;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
-
+use lib <lib blib>;
 
 
 eval_lives_ok 'use Tree::Simple', 'Can use Tree::Simple';

--- a/t/15_Tree_Simple_height_test.t
+++ b/t/15_Tree_Simple_height_test.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 66;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 use Tree::Simple;
 

--- a/t/16_Tree_Simple_width_test.t
+++ b/t/16_Tree_Simple_width_test.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 76;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 use Tree::Simple;
 

--- a/t/20_Tree_Simple_Visitor_test.t
+++ b/t/20_Tree_Simple_Visitor_test.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 35;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 use Tree::Simple;
 use Tree::Simple::Visitor;
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 1;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 
 skip_rest('Do not have Test::Pod module');

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 1;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 
 
 skip_rest('Do not have Test::Pod::Coverage module');

--- a/t/test_visitor.t
+++ b/t/test_visitor.t
@@ -1,11 +1,7 @@
 use v6;
 use Test;
 plan 1;
-BEGIN
-{
-    @*INC.push('lib');
-    @*INC.push('blib');
-}
+use lib <lib blib>;
 use Tree::Simple;
 use Tree::Simple::Visitor;
   


### PR DESCRIPTION
`@*INC` has been removed. The new way to add module search paths is with `use lib`